### PR TITLE
Fix: Handle non-array exercises prop in ExerciseTable component

### DIFF
--- a/frontend/src/components/Exercise/ExerciseTable.jsx
+++ b/frontend/src/components/Exercise/ExerciseTable.jsx
@@ -2,10 +2,10 @@ import React, { useState } from 'react';
 import ExerciseRow from './ExerciseRow';
 import { FaSort, FaSortUp, FaSortDown } from 'react-icons/fa';
 
-const ExerciseTable = ({ exercises, handleDelete }) => {
+const ExerciseTable = ({ exercises = [], handleDelete }) => {
     const [sortConfig, setSortConfig] = useState({ key: 'description', direction: 'ascending' });
 
-    const sortedExercises = sortExercises(exercises, sortConfig);
+    const sortedExercises = Array.isArray(exercises) ? sortExercises(exercises, sortConfig) : [];
 
     const requestSort = (key) => {
         setSortConfig((prevConfig) => ({


### PR DESCRIPTION
### Problem:
The ExerciseTable component was crashing when the 'exercises' prop was not an array. This took place when i logged in as a new user. This was causing issues in rendering and sorting exercises.

### Solution:
Added a check to ensure that 'exercises' is an array before attempting to sort or render. If it's not an array, an empty array is passed to prevent the crash.

### Changes:
- Implemented a conditional check (`Array.isArray(exercises)`) to safely handle the exercises prop.
- Added a default value to the exercises variable ensuring it to be an array

This ensures that the component behaves correctly even if the 'exercises' prop is missing or incorrectly formatted.

### Testing:
- Verified the component renders correctly when 'exercises' is an array.
- Confirmed the component gracefully handles non-array or empty 'exercises' prop.
