### PR TITLE
chore: rename Fit Track to FitProgressr across docs, UI, and deployment configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![License](https://img.shields.io/github/license/narainkarthikv/fit-track)
+![License](https://img.shields.io/github/license/narainkarthikv/fitprogressr)
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
-![Last Commit](https://img.shields.io/github/last-commit/narainkarthikv/fit-track)
-[![GitHub issues](https://img.shields.io/github/issues/narainkarthikv/fit-track)](https://github.com/narainkarthikv/fit-track/issues)
-[![GitHub stars](https://img.shields.io/github/stars/narainkarthikv/fit-track)](https://github.com/narainkarthikv/fit-track/stargazers)
+![Last Commit](https://img.shields.io/github/last-commit/narainkarthikv/fitprogressr)
+[![GitHub issues](https://img.shields.io/github/issues/narainkarthikv/fitprogressr)](https://github.com/narainkarthikv/fitprogressr/issues)
+[![GitHub stars](https://img.shields.io/github/stars/narainkarthikv/fitprogressr)](https://github.com/narainkarthikv/fitprogressr/stargazers)
 
-# 🏃‍♂️ FitProgressr
+# FitProgressr
 
 **Your complete fitness journey companion built with the MERN stack.**
 
@@ -38,7 +38,7 @@ Get the entire application running in seconds:
 
 ```bash
 # Clone the repository
-git clone https://github.com/narainkarthikv/fit-track.git
+git clone https://github.com/narainkarthikv/fitprogressr.git
 cd FitProgressr
 
 # Configure environment variables
@@ -57,6 +57,11 @@ docker-compose logs -f
 - **Frontend**: http://localhost:5173
 - **Backend API**: http://localhost:5000
 - **Health Check**: http://localhost:5000/api/health
+
+**Deployments:**
+
+- **Production**: https://fitprogressr.netlify.app/
+- **Development**: https://fitprogressr-dev.vercel.app/
 
 **Useful Docker Commands:**
 
@@ -107,7 +112,7 @@ NODE_ENV=development
 PORT=5000
 JWT_SECRET=your-secret-key-here
 JWT_EXPIRATION=7d
-ATLAS_URI=mongodb+srv://username:password@cluster.mongodb.net/fittrack
+ATLAS_URI=mongodb+srv://username:password@cluster.mongodb.net/fitprogressr
 ```
 
 Start the server:
@@ -273,7 +278,7 @@ JWT_SECRET=your-super-secret-jwt-key-change-this
 JWT_EXPIRATION=7d
 
 # Database
-ATLAS_URI=mongodb+srv://username:password@cluster.mongodb.net/fittrack?retryWrites=true&w=majority
+ATLAS_URI=mongodb+srv://username:password@cluster.mongodb.net/fitprogressr?retryWrites=true&w=majority
 
 # Docker Configuration
 BACKEND_PORT=5000
@@ -543,9 +548,9 @@ npm run dev
 ### Getting Help
 
 - 📖 Check the [documentation](./CONTRIBUTING.md)
-- 🐛 [Report bugs](https://github.com/narainkarthikv/fit-track/issues)
-- 💬 [Ask questions](https://github.com/narainkarthikv/fit-track/discussions)
-- 💡 [Request features](https://github.com/narainkarthikv/fit-track/issues)
+- 🐛 [Report bugs](https://github.com/narainkarthikv/fitprogressr/issues)
+- 💬 [Ask questions](https://github.com/narainkarthikv/fitprogressr/discussions)
+- 💡 [Request features](https://github.com/narainkarthikv/fitprogressr/issues)
 
 ## 📖 Documentation
 
@@ -558,8 +563,8 @@ npm run dev
 
 Thanks to everyone who has helped make FitProgressr awesome! 💪
 
-<a href="https://github.com/narainkarthikv/fit-track/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=narainkarthikv/fit-track" alt="Contributors" />
+<a href="https://github.com/narainkarthikv/fitprogressr/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=narainkarthikv/fitprogressr" alt="Contributors" />
 </a>
 
 See the [Contributors Page](./Contributors.md) for the full list.
@@ -572,9 +577,9 @@ This project is licensed under the **MIT License** - see [MIT-LICENSE.txt](./MIT
 
 ## 💬 Community & Support
 
-- **Issues**: [Report bugs or request features](https://github.com/narainkarthikv/fit-track/issues)
-- **Discussions**: [Ask questions and share ideas](https://github.com/narainkarthikv/fit-track/discussions)
-- **Pull Requests**: [Contribute code improvements](https://github.com/narainkarthikv/fit-track/pulls)
+- **Issues**: [Report bugs or request features](https://github.com/narainkarthikv/fitprogressr/issues)
+- **Discussions**: [Ask questions and share ideas](https://github.com/narainkarthikv/fitprogressr/discussions)
+- **Pull Requests**: [Contribute code improvements](https://github.com/narainkarthikv/fitprogressr/pulls)
 
 ## 🌟 Show Your Support
 
@@ -616,7 +621,7 @@ Want to help build these features? Check out our [Contributing Guide](./CONTRIBU
 
 ## 🙏 Acknowledgments
 
-- Thanks to all our [contributors](./Contributors.md) who have helped build Fit-Track
+- Thanks to all our [contributors](./Contributors.md) who have helped build FitProgressr
 - Built with amazing open-source technologies
 - Inspired by the fitness and developer communities
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ We support the latest release on the default branch.
 Please do not open public issues for security reports.
 
 - Preferred: report via GitHub Security Advisories.
-  https://github.com/narainkarthikv/fit-track/security/advisories/new
+  https://github.com/narainkarthikv/fitprogressr/security/advisories/new
 - If you cannot use GitHub advisories, open a minimal GitHub issue and request a private follow-up.
 
 We will acknowledge valid reports and work on a fix as soon as possible.

--- a/backend/server.js
+++ b/backend/server.js
@@ -36,7 +36,7 @@ const corsOptions = {
     }
 
     // Production origins from environment variables
-    // Format: FRONTEND_URL=https://fit-track.vercel.app,https://fit-track.netlify.app
+    // Format: FRONTEND_URL=https://fitprogressr.vercel.app,https://fitprogressr.netlify.app
     const frontendUrls = process.env.FRONTEND_URL
       ? process.env.FRONTEND_URL.split(',').map((url) => url.trim())
       : [];

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    container_name: fit-track-backend
+    container_name: fitprogressr-backend
     environment:
       NODE_ENV: ${NODE_ENV}
       JWT_SECRET: ${JWT_SECRET}
@@ -17,7 +17,7 @@ services:
       - ./backend:/app
       - /app/node_modules
     networks:
-      - fit-track-network
+      - fitprogressr-network
     restart: unless-stopped
     command: npm run dev
 
@@ -29,7 +29,7 @@ services:
       args:
         VITE_API_URL: ${VITE_API_URL}
         VITE_APININJAS: ${VITE_APININJAS}
-    container_name: fit-track-frontend
+    container_name: fitprogressr-frontend
     depends_on:
       - backend
     environment:
@@ -41,10 +41,10 @@ services:
       - ./frontend:/app
       - /app/node_modules
     networks:
-      - fit-track-network
+      - fitprogressr-network
     restart: unless-stopped
     command: npm run dev
 
 networks:
-  fit-track-network:
+  fitprogressr-network:
     driver: bridge

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,16 +24,16 @@
       property="og:description"
       content="Track workouts, view activity heatmaps, and monitor progress analytics with FitProgressr by Wisdom Fox Community."
     />
-    <meta property="og:image" content="https://wisdomfox-fitprogressr.netlify.app/favicon.svg" />
-    <meta property="og:url" content="https://wisdomfox-fitprogressr.netlify.app/" />
+    <meta property="og:image" content="https://fitprogressr.netlify.app/favicon.svg" />
+    <meta property="og:url" content="https://fitprogressr.netlify.app/" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="FitProgressr | Open-Source Fitness Tracking" />
     <meta
       name="twitter:description"
       content="Log exercises, manage routines, and stay motivated with FitProgressr."
     />
-    <meta name="twitter:image" content="https://wisdomfox-fitprogressr.netlify.app/favicon.svg" />
-    <link rel="canonical" href="https://wisdomfox-fitprogressr.netlify.app/" />
+    <meta name="twitter:image" content="https://fitprogressr.netlify.app/favicon.svg" />
+    <link rel="canonical" href="https://fitprogressr.netlify.app/" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -53,8 +53,8 @@
           "@type": "Organization",
           "name": "Wisdom Fox Community"
         },
-        "url": "https://wisdomfox-fitprogressr.netlify.app/",
-        "image": "https://wisdomfox-fitprogressr.netlify.app/favicon.svg",
+        "url": "https://fitprogressr.netlify.app/",
+        "image": "https://fitprogressr.netlify.app/favicon.svg",
         "offers": {
           "@type": "Offer",
           "price": "0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fit-track",
+  "name": "fitprogressr",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fit-track",
+      "name": "fitprogressr",
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.11.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fit-track",
+  "name": "fitprogressr",
   "private": true,
   "version": "1.0.0",
   "type": "module",

--- a/frontend/src/components/Navbar/NavBar.jsx
+++ b/frontend/src/components/Navbar/NavBar.jsx
@@ -149,7 +149,7 @@ const NavBar = ({
                   color: 'text.primary',
                 }}
               >
-                Fit-Track
+                FitProgressr
               </Typography>
             </Box>
 

--- a/frontend/src/components/Navbar/NotificationDropdown.jsx
+++ b/frontend/src/components/Navbar/NotificationDropdown.jsx
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 
 const NotificationDropdown = ({ notifications = [], toggleNotificationReadStatus }) => {
   const defaultNotifications = [
-    { id: 1, message: 'Welcome to Fit Track!', read: false },
+    { id: 1, message: 'Welcome to FitProgressr!', read: false },
     {
       id: 2,
       message: 'Your profile is 80% complete. Complete it for full',

--- a/frontend/src/components/auth/AuthModal.jsx
+++ b/frontend/src/components/auth/AuthModal.jsx
@@ -535,7 +535,7 @@ const AuthModal = ({ open, onClose, initialMode = 'login', onAuthSuccess }) => {
               >
                 <Stack spacing={1} sx={{ mb: 2.5 }}>
                   <Typography variant="h5" sx={{ fontWeight: 700 }}>
-                    {mode === 'login' ? 'Welcome back' : 'Create your Fit-Track account'}
+                    {mode === 'login' ? 'Welcome back' : 'Create your FitProgressr account'}
                   </Typography>
                   <Typography variant="body2" sx={{ color: 'text.secondary' }}>
                     {mode === 'login'

--- a/frontend/src/components/common/SignupLink.jsx
+++ b/frontend/src/components/common/SignupLink.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Box, Typography, Link } from '@mui/material';
 
 const SignupLink = ({
-  text = 'New to Fit-Track?',
+  text = 'New to FitProgressr?',
   linkText = 'Sign Up Now',
   linkTo = '/signup',
 }) => (

--- a/frontend/src/components/dashboard/CTA.jsx
+++ b/frontend/src/components/dashboard/CTA.jsx
@@ -73,7 +73,7 @@ const CTA = ({ isLoggedIn, onGetStartedClick }) => {
               fontWeight: 400,
             }}
           >
-            Join others who are using Fit-Track to stay consistent with their fitness. No
+            Join others who are using FitProgressr to stay consistent with their fitness. No
             commitments, just simple workout tracking.
           </Typography>
 

--- a/frontend/src/components/dashboard/Contributing.jsx
+++ b/frontend/src/components/dashboard/Contributing.jsx
@@ -81,7 +81,7 @@ const Contributing = () => {
               lineHeight: 1.7,
             }}
           >
-            Fit-Track stays free, always. It grows through community energy, thoughtful feedback,
+            FitProgressr stays free, always. It grows through community energy, thoughtful feedback,
             and small contributions that make a big difference.
           </Typography>
         </Box>
@@ -154,7 +154,7 @@ const Contributing = () => {
               </Typography>
             </Stack>
             <Typography variant="body1" sx={{ color: 'text.secondary', lineHeight: 1.7 }}>
-              We build Fit-Track with the community, not for the community. Share feedback,
+              We build FitProgressr with the community, not for the community. Share feedback,
               celebrate wins, and point out the rough edges so we can keep improving.
             </Typography>
           </Stack>

--- a/frontend/src/components/dashboard/Footer.jsx
+++ b/frontend/src/components/dashboard/Footer.jsx
@@ -31,7 +31,7 @@ const Footer = () => (
                 color: 'primary.main',
               }}
             >
-              Fit-Track
+              FitProgressr
             </Typography>
             <Typography
               variant="body2"
@@ -112,7 +112,7 @@ const Footer = () => (
               </Typography>
               <Stack spacing={1}>
                 <Link
-                  href="https://github.com/narainkarthikv/fit-track"
+                  href="https://github.com/narainkarthikv/fitprogressr"
                   target="_blank"
                   rel="noopener"
                   underline="none"
@@ -125,7 +125,7 @@ const Footer = () => (
                   Docs & repo
                 </Link>
                 <Link
-                  href="https://github.com/narainkarthikv/fit-track/issues"
+                  href="https://github.com/narainkarthikv/fitprogressr/issues"
                   target="_blank"
                   rel="noopener"
                   underline="none"
@@ -153,7 +153,7 @@ const Footer = () => (
               </Typography>
               <Stack spacing={1}>
                 <Link
-                  href="https://github.com/narainkarthikv/fit-track/blob/develop/CONTRIBUTING.md"
+                  href="https://github.com/narainkarthikv/fitprogressr/blob/develop/CONTRIBUTING.md"
                   target="_blank"
                   rel="noopener"
                   underline="none"
@@ -166,7 +166,7 @@ const Footer = () => (
                   Contributing
                 </Link>
                 <Link
-                  href="https://github.com/narainkarthikv/fit-track"
+                  href="https://github.com/narainkarthikv/fitprogressr"
                   target="_blank"
                   rel="noopener"
                   underline="none"
@@ -200,12 +200,12 @@ const Footer = () => (
               fontSize: '0.875rem',
             }}
           >
-            © {new Date().getFullYear()} Fit-Track. Built in the open for athletes who care.
+            © {new Date().getFullYear()} FitProgressr. Built in the open for athletes who care.
           </Typography>
 
           <Stack direction="row" spacing={2}>
             <Link
-              href="https://github.com/narainkarthikv/fit-track"
+              href="https://github.com/narainkarthikv/fitprogressr"
               target="_blank"
               rel="noopener"
               sx={{

--- a/frontend/src/components/dashboard/LandingNav.jsx
+++ b/frontend/src/components/dashboard/LandingNav.jsx
@@ -57,7 +57,7 @@ const LandingNav = ({ onSignInClick, onGetStartedClick }) => {
                 letterSpacing: '-0.02em',
               }}
             >
-              Fit-Track
+              FitProgressr
             </Typography>
           </Box>
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -10,7 +10,7 @@ import { initializeAxiosAuthInterceptor } from './utils/axiosAuthInterceptor';
 
 initializeAxiosAuthInterceptor();
 
-const THEME_MODE_KEY = 'fit-track-theme-mode';
+const THEME_MODE_KEY = 'fitprogressr-theme-mode';
 
 const AppRoot = () => {
   const [themeMode, setThemeMode] = React.useState(() => {


### PR DESCRIPTION
### Motivation
- Rebrand the project from **Fit Track** / `fit-track` to **FitProgressr** / `fitprogressr` so documentation, UI, and deployment references are consistent with the new product identity. 

### Description
- Updated repository and README references including badges, clone URLs, GitHub links, example MongoDB names, and added explicit production/development deployment URLs (`https://fitprogressr.netlify.app/`, `https://fitprogressr-dev.vercel.app/`).
- Updated frontend metadata and SEO entries in `frontend/index.html` (title, OG/Twitter/canonical/schema URLs and images) to `FitProgressr` and the new Netlify domain.
- Replaced UI-visible labels and copy across the frontend (navigation, footer, landing CTA, auth modal, notifications default text, signup link) to use `FitProgressr`, and updated footer GitHub links to the renamed repo path.
- Updated configuration and packaging identifiers including `frontend/package.json` and `frontend/package-lock.json` name fields, `docker-compose.yaml` container and network names, `backend/server.js` CORS example comment, `SECURITY.md` advisory URL, and the persisted theme key in `frontend/src/main.jsx` to `fitprogressr-theme-mode`.

### Testing
- Ran a repository-wide search with `rg -n "Fit Track|fit-track|fittrack|Fit-Track" .` and confirmed no remaining matches for the old names.
- Built the frontend with `npm --prefix frontend run build` which completed successfully (build warnings about large chunks were informational only).
- Ran lint with `npm --prefix frontend run lint` which reported existing lint errors not introduced by this rename, so lint did not pass but failures are pre-existing and unrelated to branding changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e308bed7a8832d8ea4978a76fd2f84)